### PR TITLE
feature/subs: Add support for aliases and subdomains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # iMSCP LetsEncrypt Plugin - Changelog
 
+## Version 1.1.0
+
+* Implement #1 Support for aliases and subdomains
+
 ## Version 1.0.2
 
 * Fix #2 Plugin blocked delete domain / customer
@@ -13,4 +17,4 @@
 
 ### Known Limitations
 
-* Doesn't support subdomains or aliases
+* Doesn't support subdomains of aliases

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Testing and bug reports are welcome.
 1. Upload the plugin through the plugin management interface
 2. Install the plugin through the plugin management interface
 
-## Limitations
-
-* Only works for domains, not sub-domains or aliases.  Its a future feature.
-
 ## License
 
 ```

--- a/backend/LetsEncrypt.pm
+++ b/backend/LetsEncrypt.pm
@@ -288,7 +288,7 @@ sub _init
 {
     my $self = shift;
 
-    $self->{'testmode'} = 1;
+    $self->{'testmode'} = 0;
 
     $self->{'db'} = iMSCP::Database->factory();
     $self->{'httpd'} = Servers::httpd->factory();

--- a/backend/LetsEncrypt.pm
+++ b/backend/LetsEncrypt.pm
@@ -35,6 +35,7 @@ use iMSCP::Rights;
 use iMSCP::Service;
 use iMSCP::TemplateParser;
 use Servers::httpd;
+use Socket;
 use version;
 use parent 'Common::SingletonClass';
 
@@ -237,16 +238,17 @@ sub run
 
     my @sql;
     for(values %{$rows}) {
+        my ($type, $id) = $self->_domainTypeAndId($_->{'domain_id'}, $_->{'alias_id'}, $_->{'subdomain_id'});
         if ($_->{'status'} =~ /^to(?:add|change)$/) {
-            my $rs = $self->_addCertificate( $_->{'domain_id'}, $_->{'cert_name'}, $_->{'alias_id'}, $_->{'subdomain_id'} );
-            $rs |= $self->_updateForward(  $_->{'domain_id'}, $_->{'cert_name'}, $_->{'http_forward'} );
+            my $rs = $self->_addCertificate( $type, $id, $_->{'cert_name'} );
+            $rs |= $self->_updateForward( $type, $id, $_->{'cert_name'}, $_->{'http_forward'} );
             @sql = (
                 'UPDATE letsencrypt SET status = ? WHERE letsencrypt_id = ?',
                 ($rs ? scalar getMessageByType( 'error' ) || 'Unknown error' : 'ok'), $_->{'letsencrypt_id'}
             );
         } elsif ($_->{'status'} eq 'todelete') {
-            my $rs = $self->_deleteCertificate( $_->{'domain_id'}, $_->{'cert_name'}, $_->{'alias_id'}, $_->{'subdomain_id'} );
-            $rs |= $self->_updateForward(  $_->{'domain_id'}, $_->{'cert_name'}, 0 );
+            my $rs = $self->_deleteCertificate( $type, $id, $_->{'cert_name'} );
+            $rs |= $self->_updateForward( $type, $id, $_->{'cert_name'}, 0 );
             if ($rs) {
                 @sql = (
                     'UPDATE letsencrypt SET status = ? WHERE letsencrypt_id = ?',
@@ -286,6 +288,8 @@ sub _init
 {
     my $self = shift;
 
+    $self->{'testmode'} = 1;
+
     $self->{'db'} = iMSCP::Database->factory();
     $self->{'httpd'} = Servers::httpd->factory();
 
@@ -298,6 +302,31 @@ sub _init
     iMSCP::EventManager->getInstance()->register( 'afterHttpdBuildConf', sub { $self->_onAfterHttpdBuildConf( @_ ); } );
 
     $self;
+}
+
+=item _domainTypeAndId($domainId, $aliasId, $subdomainId)
+
+ Returns ($domainType, $id)
+
+ It is expected that one and only one of the given ID's would be > 0
+
+ Param int $domainId Domain unique identifier ( 0 if this is not a domain )
+ Param int $aliasId Domain alias unique identifier ( 0 if no domain alias )
+ Param int $subdomainId Domain subdomain unique identifier ( 0 if no domain alias )
+
+=cut
+
+sub _domainTypeAndId
+{
+    my ($self, $domainId, $aliasId, $subdomainId) = @_;
+    if ($domainId > 0) {
+        return ('dmn', $domainId);
+    } elsif ($aliasId) {
+        return ('als', $aliasId);
+    } elsif ($subdomainId) {
+        return ('sub', $subdomainId);
+    }
+    return ('', 0);
 }
 
 =item _addCertificate($domainId, $certName, $aliasId, $subdomainId)
@@ -315,7 +344,7 @@ sub _init
 
 sub _addCertificate
 {
-    my ($self, $domainId, $certName, $aliasId, $subdomainId) = @_;
+    my ($self, $type, $id, $certName) = @_;
     # This action must be idempotent ( this allow to handle 'tochange' status which include key renewal )
 
     debug("_addCertificate ");
@@ -324,19 +353,19 @@ sub _addCertificate
     my $rs = 0;
     my $ssl_cert = $self->{'db'}->doQuery(
         'domain_id', 'SELECT * FROM ssl_certs WHERE domain_type = ? AND domain_id = ?',
-        'dmn', $domainId
+        $type, $id
     );
-    if (exists $ssl_cert->{$domainId}) {
+    if (exists $ssl_cert->{$id}) {
         $rs = $self->{'db'}->doQuery(
             'u',
             "UPDATE ssl_certs SET status = 'ok' WHERE domain_type = ? AND domain_id = ? ",
-            'dmn', $domainId
+            $type, $id
         );
     } else {
         $rs = $self->{'db'}->doQuery(
             'i',
             "INSERT INTO ssl_certs (status, domain_type, domain_id) VALUES ('ok', ?, ?)",
-            'dmn', $domainId
+            $type, $id
         );
     }
     unless (ref $rs eq 'HASH') {
@@ -344,12 +373,15 @@ sub _addCertificate
         return 1;
     }
 
-    if (!gethostbyname($certName)) {
+    # TODO This will not work for test domains (I think) CP 2017-09-05
+    # TODO This function can go to the type of the function CP 2017-09-05
+    if (!$self->{'testmode'} && !gethostbyname($certName)) {
         error("Cannot resolve $certName");
         return 1;
     }
 
     # Create the fake cert file, its not valid PEM but that doesn't matter.
+    # TODO Does this have to be before the certbot call? If not, we could put it below and use links. CP 2017-09-05
     my $certificate = iMSCP::File->new( filename => "$main::imscpConfig{'GUI_ROOT_DIR'}/data/certs/$certName.pem");
     $certificate->set('LetsEncrypt Dummy Certificate');
     $certificate->save();
@@ -358,8 +390,10 @@ sub _addCertificate
     my $haveWWW = gethostbyname($certNameWWW) ? 1 : 0;
 
     # Call certbot-auto to create the key and certificate under /etc/letsencrypt
-    # my $certbot = $main::imscpConfig{'PLUGINS_DIR'}.'/LetsEncrypt/backend/certbot-auto-test.pm';
     my $certbot = 'certbot-auto';
+    if ($self->{'testmode'}) {
+        $certbot = $main::imscpConfig{'PLUGINS_DIR'}.'/LetsEncrypt/backend/certbot-auto-test.pm';
+    }
     my ($stdout, $stderr);
     my $command = $certbot . " certonly --apache --no-bootstrap --non-interactive -v -d " . escapeShell($certName);
     if ($haveWWW) {
@@ -374,7 +408,7 @@ sub _addCertificate
     $rs == 0 or die( $stderr || "unknown error $rs" );
 
     # Trigger an onchange to rebuild the domain, our event listener will then help process the domain config rebuild.
-    $self->_triggerDomainOnChange($domainId);
+    $self->_triggerDomainOnChange($type, $id);
  
     # my $rs = $self->_deleteCertificate( $domainId, $aliasId, $domain );
     # return $rs if $rs;
@@ -384,14 +418,32 @@ sub _addCertificate
 
 sub _triggerDomainOnChange
 {
-    my ($self, $domainId) = @_;
+    my ($self, $type, $id) = @_;
 
     # Trigger an onchange to rebuild the domain, our event listener will then help process the domain config rebuild.
-    my $rs = $self->{'db'}->doQuery(
-        'u',
-        "UPDATE domain SET domain_status = 'toadd' WHERE domain_id = ? ",
-        $domainId
-    );
+    my $rs;
+    if ($type eq 'dmn') {
+        $rs = $self->{'db'}->doQuery(
+            'u',
+            "UPDATE domain SET domain_status = 'toadd' WHERE domain_id = ? ",
+            $id
+        );
+    } elsif ($type eq 'als') {
+        $rs = $self->{'db'}->doQuery(
+            'u',
+            "UPDATE domain_aliasses SET alias_status = 'toadd' WHERE alias_id = ? ",
+            $id
+        );
+    } elsif ($type eq 'sub') {
+        $rs = $self->{'db'}->doQuery(
+            'u',
+            "UPDATE subdomain SET subdomain_status = 'toadd' WHERE subdomain_id = ? ",
+            $id
+        );
+    } else {
+        error ( 'Unsupported domain type ' . $type);
+        return 2;
+    }
     unless (ref $rs eq 'HASH') {
         error( $rs );
         return 1;
@@ -436,7 +488,7 @@ EOF
     0;
 }
 
-=item _updateForward($domainId, $certName, $doForward)
+=item _updateForward($type, $id, $certName, $doForward)
 
  Updates the forward (redirect) status of the domain 'certName' to enable
  either http or the redirect of http -> https for the domain.
@@ -450,14 +502,14 @@ EOF
 
 sub _updateForward
 {
-    my ($self, $domainId, $certName, $doForward) = @_;
+    my ($self, $type, $id, $certName, $doForward) = @_;
 
     # Update the domains table with the forward info
     my $hsts = ($doForward eq '1') ? 'on' : 'off';
     my $rs = $self->{'db'}->doQuery(
         'u',
-        "UPDATE ssl_certs SET allow_hsts = ? WHERE domain_id = ? ",
-        $hsts, $domainId
+        "UPDATE ssl_certs SET allow_hsts = ? WHERE domain_type = ? AND domain_id = ? ",
+        $hsts, $type, $id
     );
     unless (ref $rs eq 'HASH') {
         error( $rs );
@@ -469,11 +521,12 @@ sub _updateForward
     0;
 }
 
-=item _deleteCertificate($domainId, $certName, $aliasId, $domain)
+=item _deleteCertificate($type, $id, $certName)
 
  Removes LetsEncrypt SSL certificate from the domain
 
- Param int $domainId Domain unique identifier
+ Param string $type Domain type (dmn|als|sub)
+ Param int $id Domain unique identifier
  Param int $aliasId Domain alias unique identifier (0 if no domain alias)
  Return int 0 on success, other on failure
 
@@ -481,14 +534,14 @@ sub _updateForward
 
 sub _deleteCertificate
 {
-    my ($self, $domainId, $certName, $aliasId, $domain) = @_;
+    my ($self, $type, $id, $certName) = @_;
 
     # Fake out the SSL_SUPPORT in the Domains module by updating the ssl_certs table and creating a fake cert file
     my $rs = 0;
     $rs = $self->{'db'}->doQuery(
         'i',
         "DELETE FROM ssl_certs WHERE domain_type = ? AND domain_id = ?",
-        'dmn', $domainId
+        $type, $id
     );
     unless (ref $rs eq 'HASH') {
         error( $rs );
@@ -497,10 +550,13 @@ sub _deleteCertificate
 
     # Delete the fake cert file, its not valid PEM but that doesn't matter.
     my $certificate = iMSCP::File->new( filename => "$main::imscpConfig{'GUI_ROOT_DIR'}/data/certs/$certName.pem");
-    $certificate->delFile();
+    debug($certificate->{'filename'});
+    if (-f $certificate->{'filename'}) {
+        $certificate->delFile();
+    }
 
     # Trigger an onchange to rebuild the domain, our event listener will then help process the domain config rebuild.
-    $self->_triggerDomainOnChange($domainId);
+    $self->_triggerDomainOnChange($type, $id);
  
     0;
 }

--- a/backend/certbot-auto-test.pm
+++ b/backend/certbot-auto-test.pm
@@ -12,12 +12,15 @@ my $store_path = '/etc/letsencrypt/live/';
 # Pickup the domain name(s) from the -d options on the command line
 my $domain = 'test1.local';
 @options;
+#  certonly --apache --no-bootstrap --non-interactive -v -d
 GetOptions(
+    'apache', sub {  },
     'domain|d=s', sub { $domain = $_[1] },
     'no-bootstrap', sub {  },
     'non-interactive', sub {  },
     'no-self-update', sub {  },
     'verbose|v', sub {  },
+    'help|h', sub { showUsage(); },
     @options,
 ) or showUsage();
 
@@ -28,8 +31,9 @@ mkpath($store_path);
 $domain =~ s/www.//;
 
 my $domain_store_path = '/etc/letsencrypt/live/' . $domain;
-my $key_file = $domain_store_path . '/' . $domain . '.key';
-my $cert_file = $domain_store_path . '/' . $domain . '.pem';
+my $key_file = $domain_store_path . '/' . 'privkey.pem';
+my $cert_file = $domain_store_path . '/' . 'cert.pem';
+my $chain_file = $domain_store_path . '/' . 'chain.pem';
 
 # Ensure the domain store path exists
 mkpath($domain_store_path);
@@ -38,6 +42,8 @@ mkpath($domain_store_path);
 execute('openssl genrsa -out ' . $key_file . ' 2048');
 # Create the cert
 execute('openssl req -x509 -new -key ' . $key_file . ' -subj /CN=' . $domain . ' -days 3650 -out ' . $cert_file);
+# Create the chain
+execute('openssl req -x509 -new -key ' . $key_file . ' -subj /CN=' . $domain . ' -days 3650 -out ' . $chain_file);
 
 # Done
 

--- a/frontend/client/letsencrypt.php
+++ b/frontend/client/letsencrypt.php
@@ -65,31 +65,26 @@ function letsencrypt_generateDomains($tpl)
         array($_SESSION['user_id'])
     );
 
-    if ($stmt->rowCount()) {
-        while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
-            if (!$row['status']) {
-                $row['status'] = 'disabled';
-            }
-            $statusIcon = letsencrypt_statusIcon($row['status']);
-            $type = 'domain';
-            $id = $row['domain_id'];
-
-            $tpl->assign(array(
-                'DOMAIN_NAME'      => decode_idna($row['domain_name']),
-                'ID'               => $row['domain_id'],
-                'NOTE'             => $row['state'] ? $row['state'] : '',
-                'EDIT'             => tr('Edit'),
-                'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
-                'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
-                'STATUS_ICON'      => $statusIcon,
-                'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
-                'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
-            ));
-            $tpl->parse('DOMAIN_ITEM', 'domain_item'); // TODO
+    while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
+        if (!$row['status']) {
+            $row['status'] = 'disabled';
         }
-    // } else {
-    //     $tpl->assign('CUSTOMER_LIST', '');
-    //     set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
+        $statusIcon = letsencrypt_statusIcon($row['status']);
+        $type = 'domain';
+        $id = $row['domain_id'];
+
+        $tpl->assign(array(
+            'DOMAIN_NAME'      => decode_idna($row['domain_name']),
+            'ID'               => $row['domain_id'],
+            'NOTE'             => $row['state'] ? $row['state'] : '',
+            'EDIT'             => tr('Edit'),
+            'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
+            'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
+            'STATUS_ICON'      => $statusIcon,
+            'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
+            'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
+        ));
+        $tpl->parse('DOMAIN_ITEM', '.domain_item'); // TODO
     }
 }
 
@@ -114,32 +109,36 @@ function letsencrypt_generateDomains($tpl)
          array($_SESSION['user_id'])
      );
  
-     if ($stmt->rowCount()) {
-         while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
-             if (!$row['status']) {
-                 $row['status'] = 'disabled';
-             }
-             $statusIcon = letsencrypt_statusIcon($row['status']);
-             $type = 'alias';
-             $id = $row['alias_id'];
- 
-             $tpl->assign(array(
-                 'DOMAIN_NAME'      => decode_idna($row['alias_name']),
-                 'ID'               => $row['alias_id'],
-                 'NOTE'             => $row['state'] ? $row['state'] : '',
-                 'EDIT'             => tr('Edit'),
-                 'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
-                 'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
-                 'STATUS_ICON'      => $statusIcon,
-                 'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
-                 'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
-             ));
-             $tpl->parse('ALS_ITEM', 'als_item'); // TODO
-         }
-     // } else {
-     //     $tpl->assign('CUSTOMER_LIST', '');
-     //     set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
-     }
+    if (!$stmt->rowCount()) {
+        $tpl->assign(array(
+            'ALS_MSG' => tr('You do not have domain aliases.'),
+            'ALS_LIST' => ''
+        ));
+        return;
+    }
+
+    while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
+        if (!$row['status']) {
+            $row['status'] = 'disabled';
+        }
+        $statusIcon = letsencrypt_statusIcon($row['status']);
+        $type = 'alias';
+        $id = $row['alias_id'];
+
+        $tpl->assign(array(
+            'DOMAIN_NAME'      => decode_idna($row['alias_name']),
+            'ID'               => $row['alias_id'],
+            'NOTE'             => $row['state'] ? $row['state'] : '',
+            'EDIT'             => tr('Edit'),
+            'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
+            'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
+            'STATUS_ICON'      => $statusIcon,
+            'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
+            'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
+        ));
+        $tpl->parse('ALS_ITEM', '.als_item'); // TODO
+    }
+    $tpl->assign('ALS_MESSAGE', '');
  }
  
 /**
@@ -163,32 +162,36 @@ function letsencrypt_generateDomains($tpl)
          array($_SESSION['user_id'])
      );
  
-     if ($stmt->rowCount()) {
-         while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
-             if (!$row['status']) {
-                 $row['status'] = 'disabled';
-             }
-             $statusIcon = letsencrypt_statusIcon($row['status']);
-             $type = 'subdomain';
-             $id = $row['subdomain_id'];
- 
-             $tpl->assign(array(
-                 'DOMAIN_NAME'      => decode_idna($row['subdomain_name'] . '.' . $row['domain_name']),
-                 'ID'               => $row['subdomain_id'],
-                 'NOTE'             => $row['state'] ? $row['state'] : '',
-                 'EDIT'             => tr('Edit'),
-                 'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
-                 'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
-                 'STATUS_ICON'      => $statusIcon,
-                 'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
-                 'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
-             ));
-             $tpl->parse('SUB_ITEM', 'sub_item'); // TODO
-         }
-     // } else {
-     //     $tpl->assign('CUSTOMER_LIST', '');
-     //     set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
-     }
+    if (!$stmt->rowCount()) {
+        $tpl->assign(array(
+            'SUB_MSG' => tr('You do not have subdomains.'),
+            'SUB_LIST' => ''
+        ));
+        return;
+    }
+
+    while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
+        if (!$row['status']) {
+            $row['status'] = 'disabled';
+        }
+        $statusIcon = letsencrypt_statusIcon($row['status']);
+        $type = 'subdomain';
+        $id = $row['subdomain_id'];
+
+        $tpl->assign(array(
+            'DOMAIN_NAME'      => decode_idna($row['subdomain_name'] . '.' . $row['domain_name']),
+            'ID'               => $row['subdomain_id'],
+            'NOTE'             => $row['state'] ? $row['state'] : '',
+            'EDIT'             => tr('Edit'),
+            'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
+            'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
+            'STATUS_ICON'      => $statusIcon,
+            'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
+            'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
+        ));
+        $tpl->parse('SUB_ITEM', '.sub_item'); // TODO
+    }
+    $tpl->assign('SUB_MESSAGE', '');
  }
  
 
@@ -239,11 +242,7 @@ $tpl->assign(array(
 generateNavigation($tpl);
 letsencrypt_generateDomains($tpl);
 letsencrypt_generateAliases($tpl);
-$tpl->assign('ALS_MESSAGE', '');
-// $tpl->assign('ALS_ITEM', '');
 letsencrypt_generateSubdomains($tpl);
-$tpl->assign('SUB_MESSAGE', '');
-// $tpl->assign('SUB_ITEM', '');
 generatePageMessage($tpl);
 
 $tpl->parse('LAYOUT_CONTENT', 'page');

--- a/frontend/client/letsencrypt.php
+++ b/frontend/client/letsencrypt.php
@@ -30,23 +30,34 @@ use PDO;
  * Functions
  */
 
+function letsencrypt_statusIcon($status) {
+    $statusIcon = 'error';
+    if ($status == 'ok') {
+        $statusIcon = 'ok';
+    } elseif ($status == 'disabled') {
+        $statusIcon = 'disabled';
+    } elseif (in_array(
+        $status,
+        array('toadd', 'tochange', 'todelete', 'torestore', 'toenable', 'todisable'))
+    ) {
+        $statusIcon = 'reload';
+    }
+    return $statusIcon;
+}
+
 /**
- * Generate page
+ * Generate domains
  *
  * @param $tpl TemplateEngine
  * @return void
  */
-function letsencrypt_generatePage($tpl)
+function letsencrypt_generateDomains($tpl)
 {
-
-    //SELECT * FROM `letsencrypt` LEFT JOIN `domain` ON letsencrypt.domain_id = domain.domain_id
-    // SELECT letsencrypt_id, cert_name, http_forward, status, state
-    // FROM letsencrypt
-    // WHERE admin_id = ?
     $stmt = exec_query(
         '
             SELECT domain.domain_id AS domain_id, domain_name, domain_admin_id, http_forward, status, state
-            FROM domain LEFT JOIN letsencrypt ON (
+            FROM domain
+            LEFT JOIN letsencrypt ON (
                 domain.domain_id=letsencrypt.domain_id
             )
             WHERE domain_admin_id = ?
@@ -59,22 +70,9 @@ function letsencrypt_generatePage($tpl)
             if (!$row['status']) {
                 $row['status'] = 'disabled';
             }
-            if ($row['status'] == 'ok') {
-                $statusIcon = 'ok';
-            } elseif ($row['status'] == 'disabled') {
-                $statusIcon = 'disabled';
-            } elseif (in_array(
-                $row['status'],
-                array('toadd', 'tochange', 'todelete', 'torestore', 'toenable', 'todisable'))
-            ) {
-                $statusIcon = 'reload';
-            } else {
-                $statusIcon = 'error';
-            }
-
+            $statusIcon = letsencrypt_statusIcon($row['status']);
             $type = 'domain';
             $id = $row['domain_id'];
-            $domain_name = decode_idna($row['domain_name']);
 
             $tpl->assign(array(
                 'DOMAIN_NAME'      => decode_idna($row['domain_name']),
@@ -87,13 +85,113 @@ function letsencrypt_generatePage($tpl)
                 'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
                 'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
             ));
-            $tpl->parse('DOMAINKEY_ITEM', 'domainkey_item'); // TODO
+            $tpl->parse('DOMAIN_ITEM', 'domain_item'); // TODO
         }
-    } else {
-        $tpl->assign('CUSTOMER_LIST', '');
-        set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
+    // } else {
+    //     $tpl->assign('CUSTOMER_LIST', '');
+    //     set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
     }
 }
+
+/**
+ * Generate aliases
+ *
+ * @param $tpl TemplateEngine
+ * @return void
+ */
+ function letsencrypt_generateAliases($tpl)
+ {
+     $stmt = exec_query(
+         '
+             SELECT domain_aliasses.alias_id AS alias_id, alias_name, domain_admin_id, http_forward, status, state
+             FROM domain
+             INNER JOIN domain_aliasses ON (domain.domain_id = domain_aliasses.domain_id)
+             LEFT JOIN letsencrypt ON (
+                 domain_aliasses.alias_id=letsencrypt.alias_id
+             )
+             WHERE domain_admin_id = ?
+         ',
+         array($_SESSION['user_id'])
+     );
+ 
+     if ($stmt->rowCount()) {
+         while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
+             if (!$row['status']) {
+                 $row['status'] = 'disabled';
+             }
+             $statusIcon = letsencrypt_statusIcon($row['status']);
+             $type = 'alias';
+             $id = $row['alias_id'];
+ 
+             $tpl->assign(array(
+                 'DOMAIN_NAME'      => decode_idna($row['alias_name']),
+                 'ID'               => $row['alias_id'],
+                 'NOTE'             => $row['state'] ? $row['state'] : '',
+                 'EDIT'             => tr('Edit'),
+                 'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
+                 'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
+                 'STATUS_ICON'      => $statusIcon,
+                 'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
+                 'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
+             ));
+             $tpl->parse('ALS_ITEM', 'als_item'); // TODO
+         }
+     // } else {
+     //     $tpl->assign('CUSTOMER_LIST', '');
+     //     set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
+     }
+ }
+ 
+/**
+ * Generate subdomains
+ *
+ * @param $tpl TemplateEngine
+ * @return void
+ */
+ function letsencrypt_generateSubdomains($tpl)
+ {
+     $stmt = exec_query(
+         '
+             SELECT subdomain.subdomain_id AS subdomain_id, subdomain_name, domain_name, domain_admin_id, http_forward, status, state
+             FROM domain
+             INNER JOIN subdomain ON (domain.domain_id = subdomain.domain_id)
+             LEFT JOIN letsencrypt ON (
+                 subdomain.subdomain_id=letsencrypt.subdomain_id
+             )
+             WHERE domain_admin_id = ?
+         ',
+         array($_SESSION['user_id'])
+     );
+ 
+     if ($stmt->rowCount()) {
+         while ($row = $stmt->fetchRow(PDO::FETCH_ASSOC)) {
+             if (!$row['status']) {
+                 $row['status'] = 'disabled';
+             }
+             $statusIcon = letsencrypt_statusIcon($row['status']);
+             $type = 'subdomain';
+             $id = $row['subdomain_id'];
+ 
+             $tpl->assign(array(
+                 'DOMAIN_NAME'      => decode_idna($row['subdomain_name'] . '.' . $row['domain_name']),
+                 'ID'               => $row['subdomain_id'],
+                 'NOTE'             => $row['state'] ? $row['state'] : '',
+                 'EDIT'             => tr('Edit'),
+                 'EDIT_LINK'        => 'letsencrypt_edit.php?type=' . $type . '&id=' . $id,
+                 'STATUS'           => translate_dmn_status($row['status']), // TODO Improve the translation for ssl CP 2017-07
+                 'STATUS_ICON'      => $statusIcon,
+                 'HTTP_FORWARD'     => $row['http_forward'] ? tr('yes') : tr('no'),
+                 'HTTP_FORWRD_ICON' => $row['http_forward'] ? 'check' : '', // TODO
+             ));
+             $tpl->parse('SUB_ITEM', 'sub_item'); // TODO
+         }
+     // } else {
+     //     $tpl->assign('CUSTOMER_LIST', '');
+     //     set_page_message(tr('No domain with LetsEncrypt support has been found.'), 'static_info');
+     }
+ }
+ 
+
 
 /***********************************************************************************************************************
  * Main
@@ -108,23 +206,44 @@ if (!LetsEncrypt::customerHasLetsEncrypt(intval($_SESSION['user_id']))) {
 
 $tpl = new TemplateEngine();
 $tpl->define_dynamic(array(
-    'layout'         => 'shared/layouts/ui.tpl',
-    'page'           => '../../plugins/LetsEncrypt/themes/default/view/client/letsencrypt.tpl',
-    'page_message'   => 'layout',
-    'customer_list'  => 'page',
-    'domainkey_item' => 'customer_list'
+    'layout'                     => 'shared/layouts/ui.tpl',
+    'page'                       => '../../plugins/LetsEncrypt/themes/default/view/client/letsencrypt.tpl',
+    'page_message'               => 'layout',
+    'domain_list'                => 'page',
+    'domain_item'                => 'domain_list',
+    'domain_status_reload_true'  => 'domain_item',
+    'domain_status_reload_false' => 'domain_item',
+    'domain_aliases_block'       => 'page',
+    'als_message'                => 'domain_aliases_block',
+    'als_list'                   => 'domain_aliases_block',
+    'als_item'                   => 'als_list',
+    'als_status_reload_true'     => 'als_item',
+    'als_status_reload_false'    => 'als_item',
+    'subdomains_block'           => 'page',
+    'sub_message'                => 'subdomains_block',
+    'sub_list'                   => 'subdomains_block',
+    'sub_item'                   => 'sub_list',
 ));
 $tpl->assign(array(
-    'TR_PAGE_TITLE'   => tr('Customers / LetsEncrypt'),
-    'TR_ACTION'       => tr('Actions'),
-    'TR_DOMAIN_NAME'  => tr('Domain'),
-    'TR_HTTP_FORWARD' => tr('Forward to SSL'),
-    'TR_NOTE'         => tr('Notes'),
-    'TR_STATUS'       => tr('Status')
+    'TR_PAGE_TITLE'     => tr('Customers / LetsEncrypt'),
+    'TR_ACTION'         => tr('Actions'),
+    'TR_DOMAINS'        => tr('Domains'),
+    'TR_DOMAIN_ALIASES' => tr('Aliases'),
+    'TR_SUBDOMAINS'     => tr('Subdomains'),
+    'TR_DOMAIN_NAME'    => tr('Domain'),
+    'TR_HTTP_FORWARD'   => tr('Forward to SSL'),
+    'TR_NOTE'           => tr('Notes'),
+    'TR_STATUS'         => tr('Status')
 ));
 
 generateNavigation($tpl);
-letsencrypt_generatePage($tpl);
+letsencrypt_generateDomains($tpl);
+letsencrypt_generateAliases($tpl);
+$tpl->assign('ALS_MESSAGE', '');
+// $tpl->assign('ALS_ITEM', '');
+letsencrypt_generateSubdomains($tpl);
+$tpl->assign('SUB_MESSAGE', '');
+// $tpl->assign('SUB_ITEM', '');
 generatePageMessage($tpl);
 
 $tpl->parse('LAYOUT_CONTENT', 'page');

--- a/info.php
+++ b/info.php
@@ -21,9 +21,9 @@
 return array(
     'author' => 'Cambell Prince',
     'email' => 'cambell.prince@gmail.com',
-    'version' => '1.0.2',
+    'version' => '1.1.0',
     'require_api' => '1.0.5',
-    'date' => '2017-08-23',
+    'date' => '2017-09-05',
     'name' => 'LetsEncrypt',
     'desc' => 'Plugin that provides LetsEncrypt SSL certificates.',
     'url' => 'https://github.com/saygoweb/imscp-plugin-letsencrypt'

--- a/themes/default/view/client/letsencrypt.tpl
+++ b/themes/default/view/client/letsencrypt.tpl
@@ -1,6 +1,7 @@
+<h3 class="domains"><span>{TR_DOMAINS}</span></h3>
 
-<!-- BDP: customer_list -->
-<table>
+<!-- BDP: domain_list -->
+<table class="firstColFixed">
     <thead>
     <tr>
         <th>{TR_STATUS}</th>
@@ -11,7 +12,7 @@
     </tr>
     </thead>
     <tbody>
-    <!-- BDP: domainkey_item -->
+    <!-- BDP: domain_item -->
     <tr>
         <td><div class="icon i_{STATUS_ICON}">{STATUS}<div></td>
         <td><label for="keyid_{ID}">{DOMAIN_NAME}</label></td>
@@ -19,9 +20,72 @@
         <td>{NOTE}</td>
         <td>
             <a class="icon i_edit" href="{EDIT_LINK}" title="{EDIT}">{EDIT}</a>
-        </td>    </tr>
-    <!-- EDP: domainkey_item -->
+        </td></tr>
+    <!-- EDP: domain_item -->
     </tbody>
 </table>
-<!-- EDP: customer_list -->
+<!-- EDP: domains_list -->
 
+<!-- BDP: domain_aliases_block -->
+<h3 class="domains"><span>{TR_DOMAIN_ALIASES}</span></h3>
+<!-- BDP: als_message -->
+<div class="static_info">{ALS_MSG}</div>
+<!-- EDP: als_message -->
+<!-- BDP: als_list -->
+<table class="firstColFixed datatable">
+    <thead>
+    <tr>
+        <th>{TR_STATUS}</th>
+        <th>{TR_DOMAIN_NAME}</th>
+        <th>{TR_HTTP_FORWARD}</th>
+        <th>{TR_NOTE}</th>
+        <th>{TR_ACTION}</th>
+    </tr>
+    </thead>
+    <tbody>
+    <!-- BDP: als_item -->
+    <tr>
+        <td><div class="icon i_{STATUS_ICON}">{STATUS}<div></td>
+        <td><label for="keyid_{ID}">{DOMAIN_NAME}</label></td>
+        <td>{HTTP_FORWARD}</td>
+        <td>{NOTE}</td>
+        <td>
+            <a class="icon i_edit" href="{EDIT_LINK}" title="{EDIT}">{EDIT}</a>
+        </td></tr>
+    <!-- EDP: als_item -->
+    </tbody>
+</table>
+<!-- EDP: als_list -->
+<!-- EDP: domain_aliases_block -->
+
+<!-- BDP: subdomains_block -->
+<h3 class="domains"><span>{TR_SUBDOMAINS}</span></h3>
+<!-- BDP: sub_message -->
+<div class="static_info">{SUB_MSG}</div>
+<!-- EDP: sub_message -->
+<!-- BDP: sub_list -->
+<table class="firstColFixed datatable">
+    <thead>
+    <tr>
+        <th>{TR_STATUS}</th>
+        <th>{TR_DOMAIN_NAME}</th>
+        <th>{TR_HTTP_FORWARD}</th>
+        <th>{TR_NOTE}</th>
+        <th>{TR_ACTION}</th>
+    </tr>
+    </thead>
+    <tbody>
+    <!-- BDP: sub_item -->
+    <tr>
+        <td><div class="icon i_{STATUS_ICON}">{STATUS}<div></td>
+        <td><label for="keyid_{ID}">{DOMAIN_NAME}</label></td>
+        <td>{HTTP_FORWARD}</td>
+        <td>{NOTE}</td>
+        <td>
+            <a class="icon i_edit" href="{EDIT_LINK}" title="{EDIT}">{EDIT}</a>
+        </td></tr>
+    <!-- EDP: sub_item -->
+    </tbody>
+</table>
+<!-- EDP: sub_list -->
+<!-- EDP: subdomains_block -->


### PR DESCRIPTION
frontend
- added alias and subdomain to list view
- enhanced edit view to support alias and subdomain types

cerbot-auto-test
- added apache option (dummy)
- added help option, shows usage
- fixed key and cert file names, now privkey.pem and cert.pem
- added chain file

backend
- added alias and subdomain support
- added testmode to help with testing