### PR TITLE
bug/badcert-7: Fix SSL Certificate Invalid error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # iMSCP LetsEncrypt Plugin - Changelog
 
+## Version 1.1.1
+
+* Fix #7 Invalid Certificate error
+
 ## Version 1.1.0
 
 * Implement #1 Support for aliases and subdomains

--- a/TODO
+++ b/TODO
@@ -1,15 +1,20 @@
 
-2017-08 V1.1
-- Have a look at the template for domain overview, copy to letsencrypt
-- Populate the view for alias and subdomains
-  - Need to do the getData / query for each type
-- Start to look at the backend
+
+2017-09 v1.1.1
+- Fake cert issues
+
 - Email address in reseller settings
 - Update the tests to test for add certificate
   - Update the database then run
 
 
-2017-08 V1.0
+2017-08 v1.1
+- DONE Have a look at the template for domain overview, copy to letsencrypt
+- DONE Populate the view for alias and subdomains
+  - DONE Need to do the getData / query for each type
+- DONE Start to look at the backend
+
+2017-08 v1.0
 - DONE Make the certbot-auto-test app to mock certbot-auto for dev
   - DONE Make it honor -d
   - DONE Strip www. to allow for more than one -d option typically with www.domain

--- a/info.php
+++ b/info.php
@@ -21,9 +21,9 @@
 return array(
     'author' => 'Cambell Prince',
     'email' => 'cambell.prince@gmail.com',
-    'version' => '1.1.0',
+    'version' => '1.1.1',
     'require_api' => '1.0.5',
-    'date' => '2017-09-05',
+    'date' => '2017-09-06',
     'name' => 'LetsEncrypt',
     'desc' => 'Plugin that provides LetsEncrypt SSL certificates.',
     'url' => 'https://github.com/saygoweb/imscp-plugin-letsencrypt'

--- a/test/backend/all.t
+++ b/test/backend/all.t
@@ -1,0 +1,17 @@
+use diagnostics; # this gives you more debugging information
+use warnings;    # this warns you of bad practices
+use strict;      # this prevents silly errors
+
+use TAP::Harness;
+
+my %args = (
+    verbosity => 1,
+    color => 1,
+);
+
+my $harness = TAP::Harness->new (\%args);
+$harness->runtests(
+    # 'install.t',
+    'run.t',
+);
+

--- a/test/backend/install.t
+++ b/test/backend/install.t
@@ -1,0 +1,25 @@
+use diagnostics; # this gives you more debugging information
+use warnings;    # this warns you of bad practices
+use strict;      # this prevents silly errors
+use Cwd 'abs_path';
+use Test::More qw( no_plan ); # for the is() and isnt() functions
+
+use lib (abs_path('../../backend'), abs_path('../../../../../engine/PerlLib'));
+
+use iMSCP::Bootstrapper;
+
+use LetsEncrypt;
+
+my $bootstrapper = iMSCP::Bootstrapper->getInstance();
+$bootstrapper->getInstance()->boot(
+    {
+        mode            => 'backend',
+        nolock          => 1,
+        norequirements  => 1,
+        config_readonly => 1
+    }
+);
+
+my $plugin = Plugin::LetsEncrypt->getInstance();
+is ($plugin->install(), 0, "install ok");
+ok (-e '/usr/local/bin/certbot-auto', 'certbot-auto exists');

--- a/test/backend/letsencrypt_updateSelfSignedCert.t
+++ b/test/backend/letsencrypt_updateSelfSignedCert.t
@@ -1,0 +1,54 @@
+use diagnostics; # this gives you more debugging information
+use warnings;    # this warns you of bad practices
+use strict;      # this prevents silly errors
+use Cwd 'abs_path';
+use Test::More qw( no_plan ); # for the is() and isnt() functions
+
+use lib (abs_path('../../backend'), abs_path('../../../../../engine/PerlLib'));
+
+use iMSCP::Bootstrapper;
+
+use LetsEncrypt;
+
+my $bootstrapper = iMSCP::Bootstrapper->getInstance();
+$bootstrapper->getInstance()->boot(
+    {
+        mode            => 'backend',
+        nolock          => 1,
+        norequirements  => 1,
+        config_readonly => 1
+    }
+);
+
+my $rs = 0;
+my $result = 0;
+my $db = iMSCP::Database->factory();
+my $plugin = Plugin::LetsEncrypt->getInstance();
+
+$db->doQuery(
+    'q',
+    'TRUNCATE ssl_certs'
+);
+
+# Should insert a certificate
+$rs = $plugin->_updateSelfSignedCertificate('dmn', 1);
+is($rs, 0, "LetsEncrypt::_updateSelfSignedCertificate No records");
+
+$result = $db->doQuery(
+    'cert_id',
+    'SELECT * FROM ssl_certs'
+);
+is (scalar keys %{$result}, 1, "DB has one record");
+
+# Should pass validation and do no harm
+$rs = $plugin->_updateSelfSignedCertificate('dmn', 1);
+is($rs, 0, "LetsEncrypt::_updateSelfSignedCertificate Existing record");
+
+# Remove the private key and certificate from an exiting record.
+$result = $db->doQuery(
+    'q',
+    "UPDATE ssl_certs SET private_key='',certificate='' WHERE domain_type=? AND domain_id=?",
+    'dmn', 1
+);
+$rs = $plugin->_updateSelfSignedCertificate('dmn', 1);
+is($rs, 0, "LetsEncrypt::_updateSelfSignedCertificate Invalid record");

--- a/test/backend/run.t
+++ b/test/backend/run.t
@@ -1,0 +1,24 @@
+use diagnostics; # this gives you more debugging information
+use warnings;    # this warns you of bad practices
+use strict;      # this prevents silly errors
+use Cwd 'abs_path';
+use Test::More qw( no_plan ); # for the is() and isnt() functions
+
+use lib (abs_path('../../backend'), abs_path('../../../../../engine/PerlLib'));
+
+use iMSCP::Bootstrapper;
+
+use LetsEncrypt;
+
+my $bootstrapper = iMSCP::Bootstrapper->getInstance();
+$bootstrapper->getInstance()->boot(
+    {
+        mode            => 'backend',
+        nolock          => 1,
+        norequirements  => 1,
+        config_readonly => 1
+    }
+);
+
+my $plugin = Plugin::LetsEncrypt->getInstance();
+is ($plugin->run(), 0, "run ok");

--- a/test/backend/ssl.t
+++ b/test/backend/ssl.t
@@ -1,0 +1,53 @@
+use diagnostics; # this gives you more debugging information
+use warnings;    # this warns you of bad practices
+use strict;      # this prevents silly errors
+use Cwd 'abs_path';
+use Test::More qw( no_plan ); # for the is() and isnt() functions
+
+use lib (abs_path('../../backend'), abs_path('../../../../../engine/PerlLib'));
+
+use iMSCP::Bootstrapper;
+
+use iMSCP::Execute;
+use iMSCP::OpenSSL;
+use iMSCP::File;
+
+use LetsEncrypt;
+
+my $bootstrapper = iMSCP::Bootstrapper->getInstance();
+$bootstrapper->getInstance()->boot(
+    {
+        mode            => 'backend',
+        nolock          => 1,
+        norequirements  => 1,
+        config_readonly => 1
+    }
+);
+
+my $keyTempFile = File::Temp->new(UNLINK => 1);
+my $certTempFile = File::Temp->new(UNLINK => 1);
+
+my $cmd = [
+    'openssl', 'req', '-x509', '-nodes', '-days', '36500', '-subj', '/CN=test1.local', '-newkey', 'rsa',
+    '-keyout', $keyTempFile,
+    '-out', $certTempFile
+];
+my $rs = execute($cmd, \ my $stdout, \ my $stderr);
+# print $stdout if $stdout;
+# print $stderr if $stderr;
+my $keyFile = iMSCP::File->new(filename => $keyTempFile->filename);
+# print $keyFile->get();
+
+my $certFile = iMSCP::File->new(filename => $certTempFile->filename);
+# print $certFile->get();
+
+my $openSSL = iMSCP::OpenSSL->new(
+    # certificate_chains_storage_dir => $self->{'certsDir'},
+    # certificate_chain_name         => $self->{'domain_name'},
+    private_key_container_path     => $keyTempFile->filename,
+    certificate_container_path     => $certTempFile->filename
+    # ca_bundle_container_path       => defined $caBundleContainer ? $caBundleContainer : ''
+);
+is($openSSL->validatePrivateKey(), 0, "ssl validatePrivateKey");
+is($openSSL->validateCertificate(), 0, "ssl validateCertificate");
+is($openSSL->validateCertificateChain(), 0, "ssl validateCertificateChain");


### PR DESCRIPTION
Fix #7 SSL Certificate Invalid error.

- addCertificate now puts a valid key and self-signed certificate in the
  database to keep the SSLcertificate.pm module happy.

- update will cause a rebuild to populate the self-signed cert in the
  table.

- Minor fix to the cron.weekly/letsencrypt install

- Added tests. ssl.t demonstrates the iMSCP::OpenSSL validation of a
  self-signed certificate.  letsencrypt_updateSelfSignedCert.t is a
  simple unit test of the new _updateSelfSignedCert method.