### PR TITLE
bug/class Rename LetsEncrypt to SGW_LetsEncrypt

### DIFF
--- a/backend/SGW_LetsEncrypt.pm
+++ b/backend/SGW_LetsEncrypt.pm
@@ -280,7 +280,7 @@ sub _init
 
     # testmode enables the mocked certbot-auto that creates self-signed certificates
     # enabled = 1, disabled = 0
-    $self->{'testmode'} = 1;
+    $self->{'testmode'} = 0;
 
     $self->{'db'} = iMSCP::Database->factory();
     $self->{'httpd'} = Servers::httpd->factory();
@@ -357,7 +357,7 @@ sub _addCertificate
     # Call certbot-auto to create the key and certificate under /etc/letsencrypt
     my $certbot = 'certbot-auto';
     if ($self->{'testmode'}) {
-        $certbot = $main::imscpConfig{'PLUGINS_DIR'}.'/LetsEncrypt/backend/certbot-auto-test.pm';
+        $certbot = $main::imscpConfig{'PLUGINS_DIR'}.'/SGW_LetsEncrypt/backend/certbot-auto-test.pm';
     }
     my ($stdout, $stderr);
     my $command = $certbot . " certonly --apache --no-bootstrap --non-interactive -v -d " . escapeShell($certName);

--- a/frontend/client/letsencrypt.php
+++ b/frontend/client/letsencrypt.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * i-MSCP LetsEncrypt plugin
+ * i-MSCP SGW_LetsEncrypt plugin
  * Copyright (C) 2017 Cambell Prince <cambell.prince@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
@@ -18,11 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace LetsEncrypt;
+namespace SGW_LetsEncrypt;
 
 use iMSCP_Events as Events;
 use iMSCP_Events_Aggregator as EventManager;
-use iMSCP_Plugin_LetsEncrypt as LetsEncrypt;
+use iMSCP_Plugin_SGW_LetsEncrypt as SGW_LetsEncrypt;
 use iMSCP_pTemplate as TemplateEngine;
 use PDO;
 
@@ -203,14 +203,14 @@ function letsencrypt_generateDomains($tpl)
 EventManager::getInstance()->dispatch(Events::onClientScriptStart);
 check_login('user');
 
-if (!LetsEncrypt::customerHasLetsEncrypt(intval($_SESSION['user_id']))) {
+if (!SGW_LetsEncrypt::customerHasLetsEncrypt(intval($_SESSION['user_id']))) {
     showBadRequestErrorPage();
 }
 
 $tpl = new TemplateEngine();
 $tpl->define_dynamic(array(
     'layout'                     => 'shared/layouts/ui.tpl',
-    'page'                       => '../../plugins/LetsEncrypt/themes/default/view/client/letsencrypt.tpl',
+    'page'                       => '../../plugins/SGW_LetsEncrypt/themes/default/view/client/letsencrypt.tpl',
     'page_message'               => 'layout',
     'domain_list'                => 'page',
     'domain_item'                => 'domain_list',

--- a/frontend/client/letsencrypt_edit.php
+++ b/frontend/client/letsencrypt_edit.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * i-MSCP - internet Multi Server Control Panel
- * Copyright (C) 2010-2017 by i-MSCP Team
+ * i-MSCP SGW_LetsEncrypt plugin
+ * Copyright (C) 2017 Cambell Prince <cambell.prince@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -18,11 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace LetsEncrypt;
+namespace SGW_LetsEncrypt;
 
 use iMSCP_Events as Events;
 use iMSCP_Events_Aggregator as EventManager;
-use iMSCP_Plugin_LetsEncrypt as LetsEncrypt;
+use iMSCP_Plugin_SGW_LetsEncrypt as SGW_LetsEncrypt;
 use iMSCP_pTemplate as TemplateEngine;
 use iMSCP_Database;
 use PDO;
@@ -244,7 +244,7 @@ function client_editLetsEncrypt()
 EventManager::getInstance()->dispatch(Events::onClientScriptStart);
 check_login('user');
 
-if (!LetsEncrypt::customerHasLetsEncrypt(intval($_SESSION['user_id']))) {
+if (!SGW_LetsEncrypt::customerHasLetsEncrypt(intval($_SESSION['user_id']))) {
     showBadRequestErrorPage();
 }
 
@@ -256,7 +256,7 @@ if (!empty($_POST) && client_editLetsEncrypt()) {
 $tpl = new TemplateEngine();
 $tpl->define_dynamic(array(
     'layout'             => 'shared/layouts/ui.tpl',
-    'page'               => '../../plugins/LetsEncrypt/themes/default/view/client/letsencrypt_edit.tpl',
+    'page'               => '../../plugins/SGW_LetsEncrypt/themes/default/view/client/letsencrypt_edit.tpl',
     'page_message'       => 'layout'
 ));
 $tpl->assign(array(

--- a/info.php
+++ b/info.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * i-MSCP LetsEncrypt plugin
+ * i-MSCP SGW_LetsEncrypt plugin
  * Copyright (C) 2017 Cambell Prince <cambell.prince@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
@@ -21,9 +21,9 @@
 return array(
     'author' => 'Cambell Prince',
     'email' => 'cambell.prince@gmail.com',
-    'version' => '1.5.0',
+    'version' => '1.5.1',
     'require_api' => '1.0.5',
-    'date' => '2019-03-25',
+    'date' => '2019-06-24',
     'name' => 'SGW_LetsEncrypt',
     'desc' => 'Plugin that provides LetsEncrypt SSL certificates.',
     'url' => 'https://github.com/saygoweb/imscp-plugin-letsencrypt'


### PR DESCRIPTION
Continue fixing #19, renaming LetsEncrypt to SGW_LetsEncrypt.